### PR TITLE
Cannot import style files

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -5,7 +5,7 @@
  * You can see the styles here:
  * https://github.com/tailwindcss/tailwindcss/blob/master/css/preflight.css
  */
-@tailwind preflight;
+@import "tailwind/preflight";
 
 /**
  * Here you would add any of your custom component classes; stuff that you'd
@@ -27,7 +27,7 @@
  * This injects all of Tailwind's utility classes, generated based on your
  * config file.
  */
-@tailwind utilities;
+@import "tailwind/utilities";
 
 /**
  * Here you would add any custom utilities you need that don't come out of the

--- a/src/tailwind/preflight.css
+++ b/src/tailwind/preflight.css
@@ -1,0 +1,1 @@
+@tailwind preflight;

--- a/src/tailwind/utilities.css
+++ b/src/tailwind/utilities.css
@@ -1,0 +1,1 @@
+@tailwind utilities;


### PR DESCRIPTION
When trying to add other `@import` calls at the end of `styles.css` you get a postcss-import error like:

`postcss-import: @import must precede all other statements (besides @charset)`

This applies the fix suggested by @adamwathan in https://github.com/nuxt/nuxt.js/pull/2095