### PR TITLE
Made it work with the jekyll.environment

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -26,7 +26,14 @@ task("buildJekyll", () => {
     args.push("--incremental");
   }
 
-  return spawn("bundle", args, { stdio: "inherit" });
+  return spawn("bundle", args, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      JEKYLL_ENV: isDevelopmentBuild ? "development" : "production",
+    },
+    shell: true,
+  });
 });
 
 task("processStyles", () => {


### PR DESCRIPTION
Often we need to hide/show on the bases of jekyll built-in environment variable `jekyll.environment` like:
```html
{% if jekyll.environment == 'production' %}
  <!-- Google Tag Manager -->
  <script>
    // .....
  </script>
{% endif %}
```
So this little adjustment worked really good for me and I thought better if you add it by default as some plugins also need jekyll environment.

Thanks!